### PR TITLE
Handle possibly-null level after initial setup

### DIFF
--- a/insteonX0Dimmer.groovy
+++ b/insteonX0Dimmer.groovy
@@ -196,7 +196,10 @@ def getUnitCode() {
 }
 
 def X10Level(level) {
-    def x10level = 22 * level / 100
+    if (level == null) {
+        return null
+    }
+    def x10level = 22 * (int)level / 100
     log.debug "Level ${level} maps to ${(int)x10level}"
     (int)x10level
 }


### PR DESCRIPTION
Ran into an issue where my device state was null after the initial setup. This failed on the multiply operation so it was never initialized to 100 in the logic above.